### PR TITLE
feat: add sessionStorage wrapper with typed get/set support

### DIFF
--- a/packages/storage/src/_module/web.mts
+++ b/packages/storage/src/_module/web.mts
@@ -14,3 +14,8 @@ export {
 	localStorage,
 	type LocalStorage,
 } from '../web/local-storage/local-storage.mts'
+
+export {
+	sessionStorage,
+	type SessionStorage,
+} from '../web/local-storage/session-storage.mts'

--- a/packages/storage/src/web/local-storage/session-storage.mts
+++ b/packages/storage/src/web/local-storage/session-storage.mts
@@ -1,0 +1,165 @@
+import { jsonStringify, safeJsonParse } from '../../serializer.mts'
+
+/**
+ * Typed wrapper around {@link globalThis.Storage} for the browser's
+ * `sessionStorage`.
+ *
+ * Picks `length`, `clear`, `setItem`, and `removeItem` straight from the
+ * native {@link globalThis.Storage} interface so they keep their native
+ * signatures. On top of that it adds:
+ * - `getItem` that returns `string | undefined` instead of
+ *   `string | null`, so callers don't have to distinguish between
+ *   "stored as null" and "not present",
+ * - `key` that returns `string | undefined` for the same reason,
+ * - typed `get<T>` / `set<T>` that run values through `JSON.stringify`
+ *   and `JSON.parse` for you,
+ * - `keys()` for a plain array of keys without having to walk
+ *   `key(index)` yourself.
+ *
+ * Typed reads are safe against prototype pollution. The parsed JSON is
+ * passed through a reviver that drops `__proto__`, `constructor`, and
+ * `prototype` keys at any depth, so a hostile value written to storage
+ * (for example from DevTools or another tab) cannot walk onto
+ * `Object.prototype`.
+ *
+ * Safe to import under SSR. When `globalThis.sessionStorage` is not
+ * available reads return `undefined` / empty collections, `length`
+ * reads as `0`, and writes become no-ops, so nothing throws at import
+ * time or during the first render on the server.
+ *
+ * @example
+ * ```ts
+ * import { sessionStorage } from '@rooted/storage/web'
+ *
+ * sessionStorage.set('theme', 'dark')
+ * sessionStorage.get<string>('theme') // 'dark'
+ *
+ * sessionStorage.set<{ id: number }>('session', { id: 7 })
+ * sessionStorage.get<{ id: number }>('session') // { id: 7 }
+ *
+ * sessionStorage.removeItem('session')
+ * ```
+ */
+export type SessionStorage = Pick<globalThis.Storage, 'length' | 'clear' | 'setItem' | 'removeItem'> & {
+	/**
+	 * Read a value as its raw string. Returns `undefined` when the key
+	 * is not set.
+	 */
+	getItem(key: string): string | undefined
+	/**
+	 * Return the key at `index` in insertion order, or `undefined` when
+	 * `index` is out of range. Thin wrapper over
+	 * {@link globalThis.Storage.key} that normalises the native `null`
+	 * to `undefined`.
+	 */
+	key(index: number): string | undefined
+	/**
+	 * Typed read. Strings come back as-is, everything else is parsed
+	 * from JSON through a prototype-pollution-safe reviver. Returns
+	 * `undefined` when the key is missing.
+	 */
+	get<T = unknown>(key: string): T | undefined
+	/**
+	 * Typed write. Strings pass through unchanged so values written by
+	 * `setItem` round-trip, everything else is JSON-encoded.
+	 */
+	set<T>(key: string, value: T): void
+	/** Every key currently stored. Empty array under SSR. */
+	keys(): string[]
+}
+
+function getNative(): globalThis.Storage | undefined {
+	// `globalThis.sessionStorage` is declared as `Storage` in the DOM
+	// lib, so a direct `=== undefined` check trips the "always false"
+	// warning. Reading it through a narrower shape lets the compiler
+	// see that the property might be missing under SSR, while still
+	// returning the real `Storage` when it exists.
+	return (globalThis as { sessionStorage?: globalThis.Storage }).sessionStorage
+}
+
+function getItem(key: string): string | undefined {
+	const store = getNative()
+	if (store === undefined) return undefined
+	return store.getItem(key) ?? undefined
+}
+
+function setItem(key: string, value: string): void {
+	const store = getNative()
+	if (store === undefined) return
+	store.setItem(key, value)
+}
+
+function removeItem(key: string): void {
+	const store = getNative()
+	if (store === undefined) return
+	store.removeItem(key)
+}
+
+function clear(): void {
+	const store = getNative()
+	if (store === undefined) return
+	store.clear()
+}
+
+function key(index: number): string | undefined {
+	const store = getNative()
+	if (store === undefined) return undefined
+	return store.key(index) ?? undefined
+}
+
+function get<T = unknown>(key: string): T | undefined {
+	const raw = getItem(key)
+	if (raw === undefined) return undefined
+
+	const parsed = safeJsonParse<T>(raw)
+	if (parsed !== undefined) return parsed
+
+	// Plain-string values (written via `setItem`, or by another tab)
+	// aren't valid JSON, so `safeJsonParse` gives up on them. Hand the
+	// raw string back so `get<string>` still works.
+	return raw as T
+}
+
+function set<T>(key: string, value: T): void {
+	const serialized = typeof value === 'string' ? value : jsonStringify(value)
+	setItem(key, serialized)
+}
+
+function keys(): string[] {
+	const store = getNative()
+	if (store === undefined) return []
+
+	const result: string[] = []
+	for (let index = 0; index < store.length; index++) {
+		const name = store.key(index)
+		if (name != undefined) result.push(name)
+	}
+	return result
+}
+
+/**
+ * The singleton {@link SessionStorage} instance. Frozen so callers can't
+ * monkey-patch individual methods.
+ *
+ * @example
+ * ```ts
+ * import { sessionStorage } from '@rooted/storage/web'
+ *
+ * sessionStorage.setItem('token', 'abc123')
+ * sessionStorage.getItem('token') // 'abc123'
+ * ```
+ */
+export const sessionStorage: SessionStorage = Object.freeze({
+	clear,
+	getItem,
+	key,
+	removeItem,
+	setItem,
+	get,
+	set,
+	keys,
+	get length(): number {
+		const store = getNative()
+		return store === undefined ? 0 : store.length
+	},
+}) as unknown as SessionStorage

--- a/packages/storage/tests/session-storage.test.ts
+++ b/packages/storage/tests/session-storage.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { sessionStorage } from '../src/web/local-storage/session-storage.mts'
+
+const originalSessionStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage')
+
+function restoreSessionStorage(): void {
+	if (originalSessionStorageDescriptor) {
+		Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorageDescriptor)
+	}
+}
+
+beforeEach(() => {
+	restoreSessionStorage()
+	globalThis.sessionStorage.clear()
+})
+
+afterEach(() => {
+	restoreSessionStorage()
+	globalThis.sessionStorage.clear()
+})
+
+describe('sessionStorage — getItem / setItem', () => {
+	test('getItem returns undefined for a missing key', () => {
+		expect(sessionStorage.getItem('missing')).toBeUndefined()
+	})
+
+	test('setItem + getItem round-trip a plain string', () => {
+		sessionStorage.setItem('token', 'abc123')
+		expect(sessionStorage.getItem('token')).toBe('abc123')
+	})
+
+	test('setItem overwrites previous value', () => {
+		sessionStorage.setItem('k', 'first')
+		sessionStorage.setItem('k', 'second')
+		expect(sessionStorage.getItem('k')).toBe('second')
+	})
+
+	test('handles special characters in key and value', () => {
+		sessionStorage.setItem('key with spaces', 'value; with=specials & unicode é')
+		expect(sessionStorage.getItem('key with spaces'))
+			.toBe('value; with=specials & unicode é')
+	})
+
+	test('writes go through to the native sessionStorage', () => {
+		sessionStorage.setItem('shared', 'hello')
+		expect(globalThis.sessionStorage.getItem('shared')).toBe('hello')
+	})
+})
+
+describe('sessionStorage — typed get / set', () => {
+	test('set<number> + get<number>', () => {
+		sessionStorage.set<number>('count', 42)
+		expect(sessionStorage.get<number>('count')).toBe(42)
+	})
+
+	test('set<boolean> + get<boolean>', () => {
+		sessionStorage.set<boolean>('flag', true)
+		expect(sessionStorage.get<boolean>('flag')).toBe(true)
+	})
+
+	test('set<object> + get<object> round-trip', () => {
+		const value = { id: 1, name: 'rooted', tags: ['a', 'b'] }
+		sessionStorage.set('profile', value)
+		expect(sessionStorage.get<typeof value>('profile')).toEqual(value)
+	})
+
+	test('set<string> does not double-encode', () => {
+		sessionStorage.set<string>('greeting', 'hello')
+		expect(sessionStorage.getItem('greeting')).toBe('hello')
+		expect(sessionStorage.get<string>('greeting')).toBe('hello')
+	})
+
+	test('get<string> falls back to the raw value when the stored value is not JSON', () => {
+		// Simulates a value written via setItem (or from another tab)
+		// that stores a plain non-JSON string.
+		sessionStorage.setItem('opaque', 'opaque-token')
+		expect(sessionStorage.get<string>('opaque')).toBe('opaque-token')
+	})
+
+	test('get returns undefined for a missing key', () => {
+		expect(sessionStorage.get('missing')).toBeUndefined()
+	})
+
+	test('prototype-pollution guard: malicious value cannot pollute Object.prototype', () => {
+		sessionStorage.setItem('evil', '{"__proto__":{"polluted":"yes"}}')
+
+		const parsed = sessionStorage.get<Record<string, unknown>>('evil')
+		expect(parsed).toEqual({})
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+	})
+})
+
+describe('sessionStorage — removeItem / clear', () => {
+	test('removeItem drops a previously set value', () => {
+		sessionStorage.setItem('temp', '1')
+		expect(sessionStorage.getItem('temp')).toBe('1')
+
+		sessionStorage.removeItem('temp')
+		expect(sessionStorage.getItem('temp')).toBeUndefined()
+	})
+
+	test('clear wipes every key', () => {
+		sessionStorage.setItem('a', '1')
+		sessionStorage.setItem('b', '2')
+
+		sessionStorage.clear()
+
+		expect(sessionStorage.getItem('a')).toBeUndefined()
+		expect(sessionStorage.getItem('b')).toBeUndefined()
+		expect(sessionStorage.keys()).toEqual([])
+	})
+})
+
+describe('sessionStorage — keys', () => {
+	test('returns every key currently stored', () => {
+		sessionStorage.setItem('a', '1')
+		sessionStorage.setItem('b', '2')
+		sessionStorage.setItem('c', '3')
+
+		expect(sessionStorage.keys().toSorted()).toEqual(['a', 'b', 'c'])
+	})
+
+	test('returns an empty array when nothing is stored', () => {
+		expect(sessionStorage.keys()).toEqual([])
+	})
+})
+
+describe('sessionStorage — inherited Storage surface', () => {
+	test('length reflects the number of stored entries', () => {
+		expect(sessionStorage.length).toBe(0)
+
+		sessionStorage.setItem('a', '1')
+		sessionStorage.setItem('b', '2')
+
+		expect(sessionStorage.length).toBe(2)
+	})
+
+	test('key(index) returns keys in the native order', () => {
+		sessionStorage.setItem('a', '1')
+		sessionStorage.setItem('b', '2')
+
+		const first = sessionStorage.key(0)
+		const second = sessionStorage.key(1)
+
+		expect([first, second].toSorted()).toEqual(['a', 'b'])
+		expect(sessionStorage.key(99)).toBeUndefined()
+	})
+})
+
+describe('sessionStorage — SSR guard', () => {
+	test('does not throw when globalThis.sessionStorage is undefined', () => {
+		Object.defineProperty(globalThis, 'sessionStorage', {
+			configurable: true,
+			value: undefined,
+		})
+
+		try {
+			expect(sessionStorage.getItem('x')).toBeUndefined()
+			expect(sessionStorage.get('x')).toBeUndefined()
+			expect(sessionStorage.keys()).toEqual([])
+			expect(sessionStorage.length).toBe(0)
+			expect(sessionStorage.key(0)).toBeUndefined()
+			expect(() => sessionStorage.setItem('x', '1')).not.toThrow()
+			expect(() => sessionStorage.set('x', 1)).not.toThrow()
+			expect(() => sessionStorage.removeItem('x')).not.toThrow()
+			expect(() => sessionStorage.clear()).not.toThrow()
+		}
+		finally {
+			restoreSessionStorage()
+		}
+	})
+})
+
+describe('sessionStorage — singleton', () => {
+	test('is frozen so methods cannot be replaced', () => {
+		expect(Object.isFrozen(sessionStorage)).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

Adds a new `sessionStorage` export that mirrors the existing `localStorage` implementation. This provides a typed wrapper around the browser's native `sessionStorage` API with the same ergonomic improvements: typed `get<T>` / `set<T>` methods, prototype-pollution protection, SSR safety, and a frozen singleton instance.

## Changes

- **New module**: `packages/storage/src/web/local-storage/session-storage.mts`
  - Implements `SessionStorage` type with typed read/write methods
  - Wraps native `globalThis.sessionStorage` with SSR guards
  - Includes prototype-pollution protection via `safeJsonParse`
  - Provides `keys()` helper and normalizes `null` returns to `undefined`

- **Updated exports**: `packages/storage/src/_module/web.mts`
  - Exports `sessionStorage` singleton and `SessionStorage` type

- **Comprehensive test suite**: `packages/storage/tests/session-storage.test.ts`
  - 179 lines covering getItem/setItem, typed get/set, removeItem/clear, keys, inherited Storage surface, SSR guards, and singleton behavior

## Definition Of Done

- [x] Added new tests (179 lines of comprehensive test coverage)
- [x] All tests pass
- [x] TSDoc added for public API (`SessionStorage` type and `sessionStorage` export)
- [x] Follows existing `localStorage` implementation pattern for consistency

## Test Plan

Added 179 lines of unit tests covering:
- Basic getItem/setItem operations and round-trips
- Typed get/set with numbers, booleans, and objects
- Special character handling
- Prototype-pollution guards
- removeItem and clear operations
- keys() enumeration
- Inherited Storage interface (length, key)
- SSR safety when sessionStorage is undefined
- Singleton immutability

All tests pass and provide full coverage of the new functionality.

https://claude.ai/code/session_01KfkgtfiKq8BQXQ1phj8s6M