### PR TITLE
chore(lint): move eslint-plugin-unicorn to 72

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    ignore:
+      # Hold at TypeScript 6.x. 7.0 is the native port and ships no public compiler
+      # API, so anything reading it (our inheritdoc tsdown plugin,
+      # eslint-plugin-perfectionist) cannot run on it. A new API is planned for 7.1.
+      # Only the 7.0 series is ignored, so dependabot opens a PR by itself once 7.1
+      # is out, and CI answers whether the toolchain has caught up.
+      # See docs/adr/2026-07-26.typescript-7-hold.md.
+      - dependency-name: "typescript"
+        versions: ["7.0.x"]
     groups:
       eslint:
         patterns:

--- a/.repo/config/oxlint/oxlint.config.json
+++ b/.repo/config/oxlint/oxlint.config.json
@@ -3,7 +3,7 @@
 	"jsPlugins": [
 		"./plugin-local.mjs",
 		"eslint-plugin-perfectionist",
-		{ "name": "unicorn-js", "specifier": "eslint-plugin-unicorn" }
+		{ "name": "unicorn-js", "specifier": "./plugin-unicorn.mjs" }
 	],
 	"env": {
 		"es2022": true,

--- a/.repo/config/oxlint/plugin-unicorn.mjs
+++ b/.repo/config/oxlint/plugin-unicorn.mjs
@@ -1,0 +1,35 @@
+// Wrapper around eslint-plugin-unicorn, loaded via jsPlugins in oxlint.config.json.
+//
+// oxlint validates every rule's `meta.defaultOptions` against that rule's own
+// `meta.schema` when it registers a JS plugin. eslint-plugin-unicorn 72.0.0 ships
+// `defaultOptions: [undefined]` on `logical-assignment-operators`, and its schema
+// only accepts "always" or "never", so the check fails and oxlint refuses to load
+// the whole plugin. ESLint itself never notices, because it reads an empty slot as
+// "no option given". (oxlint reports the value as `null`, that's just how JSON
+// prints an undefined array entry.)
+//
+// Dropping those empty slots gets us back to the ESLint behaviour. Once upstream
+// fixes the metadata this file can go and oxlint.config.json can point at the
+// package again.
+
+import unicorn from 'eslint-plugin-unicorn'
+
+/** Strip empty `defaultOptions` entries, and the key itself if nothing is left. */
+function withoutEmptyDefaults(rule) {
+	const defaults = rule.meta?.defaultOptions
+	if (!defaults?.some((option) => option === null || option === undefined)) return rule
+
+	const kept = defaults.filter((option) => option !== null && option !== undefined)
+	const meta = { ...rule.meta }
+	if (kept.length === 0) delete meta.defaultOptions
+	else meta.defaultOptions = kept
+
+	return { ...rule, meta }
+}
+
+export default {
+	...unicorn,
+	rules: Object.fromEntries(
+		Object.entries(unicorn.rules).map(([name, rule]) => [name, withoutEmptyDefaults(rule)]),
+	),
+}

--- a/.repo/config/oxlint/preset.custom.json
+++ b/.repo/config/oxlint/preset.custom.json
@@ -2,7 +2,11 @@
 	"rules": {
 		"local/mjs-to-mts": "error",
 		"local/utf-encoding": "error",
-		"unicorn-js/prevent-abbreviations": ["error", {
+		"unicorn-js/name-replacements": ["error", {
+			"replacements": {
+				"application": false,
+				"applications": false
+			},
 			"allowList": {
 				"dev": true,
 				"dev.mts": true,

--- a/docs/adr/2026-07-26.typescript-7-hold.md
+++ b/docs/adr/2026-07-26.typescript-7-hold.md
@@ -1,0 +1,30 @@
+# `ADR` Hold at TypeScript 6 until 7.1
+
+```yml
+status: accepted
+created: 2026-07-26
+deciders:
+- marvin-brouwer
+```
+
+TypeScript 7.0 is the native port. It ships no public compiler API at all: the package entry exports nothing beyond `version`, and a replacement lives under `typescript/unstable/*` that upstream still labels experimental. A new API is planned for 7.1, and it is a different API, not the old one restored.
+
+Two things in this repo read that API. Ours is `tooling/tsdown/src/inheritdoc.mts`, which walks the AST and asks a `TypeChecker` to resolve inherited members so `{@inheritdoc}` tags can be expanded into the emitted `.d.mts` files. The other is `eslint-plugin-perfectionist`, whose `sort-imports` rule reaches for the TypeScript API without declaring a dependency on it and picks up whatever the tree hoists. On 7 it crashes on `isExternalModuleNameRelative`. This is not specific to us: typescript-eslint, the Vue, Svelte, Astro and Angular template checkers, and the webpack loaders are all on 6.x for the same reason.
+
+Adopting 7.0 was tried and it does work. `tooling/tsdown` imports the compiler API through an alias pinned to 6.x, a `packageExtensions` entry hands perfectionist a 6.x copy, and with those two pins in place the full pipeline passes and the emitted declarations are byte for byte identical to the 6.0.3 build. So the question was never whether it can be made to run, it was whether the pins are worth it.
+
+## Decision
+
+Stay on TypeScript 6.x. Dependabot ignores the `7.0.x` series only, so it opens a pull request on its own once 7.1 is released, and CI is what answers whether the toolchain has caught up.
+
+## Consequences
+
+**No pins to carry.** Nothing in the repo has to explain why one dependency is held at a different major than the rest, and there is no alias for a reader to decode.
+
+**We give up a faster `tsc`.** That is the whole of what 7.0 offers us today. Type checking is not currently a bottleneck here, and the emitted output does not change, so the trade is cheap.
+
+**Two known emit differences are deferred, not avoided.** Whenever we do move, the api reports pick up changes: string literals switch to single quotes, and `isDevelopment()` infers `boolean` where 6 gives up and says `any`. Neither is a break, both are noise in the first diff after the upgrade.
+
+**6.x is a dead end, so this is a delay and not a resting place.** 6.0 is the last release built on the JavaScript codebase and is in maintenance, taking only security fixes and high-severity regressions. Sitting here indefinitely is not an option.
+
+**The inheritdoc plugin needs work either way.** When 7.1 lands, its new API is not the one that plugin is written against. Moving off 6.x means porting `inheritdoc.mts` or keeping a 6.x copy around purely for it. Waiting removes the perfectionist workaround, because that is upstream's to fix, but not this one.

--- a/examples/recipe-book/plugins/responsive-images.mts
+++ b/examples/recipe-book/plugins/responsive-images.mts
@@ -277,11 +277,11 @@ function buildModule(images: ImageEntry[], sourceUrl: string, author: string): s
 	// URLs may be `import.meta.ROLLUP_FILE_URL_*` tokens that Rollup resolves
 	// only when they appear as real JS expressions — not inside string literals.
 	// Emit them as raw expressions so Rollup can replace them correctly.
-	const urlExpr = (url: string) => url.startsWith('import.meta.') ? url : JSON.stringify(url)
+	const urlExpression = (url: string) => url.startsWith('import.meta.') ? url : JSON.stringify(url)
 	const imagesLiteral = '[\n' + images.map(img =>
-		`  { "url": ${urlExpr(img.url)}, "width": ${img.width} }`,
+		`  { "url": ${urlExpression(img.url)}, "width": ${img.width} }`,
 	).join(',\n') + '\n]'
-	const sourceSetLiteral = '`' + images.map(img => `\${${urlExpr(img.url)}} ${img.width}w`).join(', ') + '`'
+	const sourceSetLiteral = '`' + images.map(img => `\${${urlExpression(img.url)}} ${img.width}w`).join(', ') + '`'
 	return [
 		`export const images = ${imagesLiteral}`,
 		`export const sourceSet = ${sourceSetLiteral}`,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@rooted/pipeline": "workspace:*",
 		"@types/unist": "^3.0.3",
 		"eslint-plugin-perfectionist": "^5.10.0",
-		"eslint-plugin-unicorn": "^66.0.0",
+		"eslint-plugin-unicorn": "^72.0.0",
 		"happy-dom": "^20.11.1",
 		"husky": "^9.1.7",
 		"multi-semantic-release": "^3.1.0",

--- a/packages/application/plugins/import-cycle-detector.mts
+++ b/packages/application/plugins/import-cycle-detector.mts
@@ -144,8 +144,8 @@ function canReachViaStaticImports(
 	if (from === target) return true
 	if (visited.has(from)) return false
 	visited.add(from)
-	for (const dep of staticImports.get(from) ?? []) {
-		if (canReachViaStaticImports(dep, target, staticImports, visited)) return true
+	for (const dependency of staticImports.get(from) ?? []) {
+		if (canReachViaStaticImports(dependency, target, staticImports, visited)) return true
 	}
 	return false
 }

--- a/packages/elements/src/element-factory.mts
+++ b/packages/elements/src/element-factory.mts
@@ -29,11 +29,11 @@ function buildClassList(classes: CssClasses | undefined) {
 }
 
 function isWritableDomProperty(element: Element, key: string): boolean {
-	let proto: object | null = element
-	while (proto) {
-		const desc = Object.getOwnPropertyDescriptor(proto, key)
+	let prototype: object | null = element
+	while (prototype) {
+		const desc = Object.getOwnPropertyDescriptor(prototype, key)
 		if (desc) return !!(desc.writable || desc.set)
-		proto = Object.getPrototypeOf(proto) as object | null
+		prototype = Object.getPrototypeOf(prototype) as object | null
 	}
 	return false
 }

--- a/packages/storage/tests/cookie-storage.test.ts
+++ b/packages/storage/tests/cookie-storage.test.ts
@@ -23,8 +23,8 @@ function restoreCookieProperty(): void {
 	// If the prototype descriptor is still in place we're done; otherwise
 	// reinstall it on the instance as a safety net.
 	if (!Object.getOwnPropertyDescriptor(document, 'cookie')) {
-		const proto = Object.getPrototypeOf(document) as object | null
-		if (!proto || !Object.getOwnPropertyDescriptor(proto, 'cookie')) {
+		const prototype = Object.getPrototypeOf(document) as object | null
+		if (!prototype || !Object.getOwnPropertyDescriptor(prototype, 'cookie')) {
 			Object.defineProperty(document, 'cookie', {
 				...originalCookieDescriptor,
 				configurable: true,

--- a/packages/store/src/deepClone.mts
+++ b/packages/store/src/deepClone.mts
@@ -55,10 +55,10 @@ export function deepClone<T>(value: T, seen: WeakMap<object, unknown> = new Weak
 		return copy as unknown as T
 	}
 
-	const proto = Object.getPrototypeOf(object)
-	const copy = (proto === Object.prototype || proto === null)
+	const prototype = Object.getPrototypeOf(object)
+	const copy = (prototype === Object.prototype || prototype === null)
 		? {} as Record<string | symbol, unknown>
-		: Object.create(proto) as Record<string | symbol, unknown>
+		: Object.create(prototype) as Record<string | symbol, unknown>
 	seen.set(object, copy)
 	for (const key of Reflect.ownKeys(object)) {
 		const v = (object as Record<string | symbol, unknown>)[key]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^5.10.0
         version: 5.10.0(eslint@10.3.0(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-unicorn:
-        specifier: ^66.0.0
-        version: 66.0.0(eslint@10.3.0(jiti@2.7.0))
+        specifier: ^72.0.0
+        version: 72.0.0(eslint@10.3.0(jiti@2.7.0))
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1
@@ -40,7 +40,7 @@ importers:
         version: 3.1.0(typescript@6.0.3)
       oxlint:
         specifier: ^1.75.0
-        version: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)))
+        version: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(tsx@4.23.1)(typescript@6.0.3)
@@ -49,13 +49,13 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: ^0.2.6
-        version: 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+        version: 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.1)(change-case@5.4.4)(lightningcss@1.33.0)(postcss@8.5.23)(search-insights@2.17.3)(terser@5.49.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+        version: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   examples/recipe-book:
     dependencies:
@@ -83,7 +83,7 @@ importers:
         version: 7.0.2
       '@varlock/vite-integration':
         specifier: ^1.3.1
-        version: 1.3.1(varlock@1.13.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+        version: 1.3.1(varlock@1.13.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -101,7 +101,7 @@ importers:
         version: 1.13.0
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapter:
     dependencies:
@@ -129,7 +129,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/aws-s3:
     devDependencies:
@@ -153,7 +153,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/azure-blob:
     devDependencies:
@@ -177,7 +177,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/azure-static-webapp:
     devDependencies:
@@ -201,7 +201,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/cloudflare-pages:
     devDependencies:
@@ -225,7 +225,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/cloudflare-r2:
     devDependencies:
@@ -249,7 +249,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/codeberg-pages:
     devDependencies:
@@ -273,7 +273,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/express:
     dependencies:
@@ -307,7 +307,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/fastify:
     dependencies:
@@ -341,7 +341,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/firebase-hosting:
     devDependencies:
@@ -365,7 +365,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/gcp-cloud-storage:
     devDependencies:
@@ -389,7 +389,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/git-pages:
     devDependencies:
@@ -413,7 +413,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/github-pages:
     devDependencies:
@@ -437,7 +437,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/gitlab-pages:
     devDependencies:
@@ -461,7 +461,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/netlify-hosting:
     devDependencies:
@@ -485,7 +485,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/scaleway-object-storage:
     devDependencies:
@@ -509,7 +509,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/static-site:
     devDependencies:
@@ -533,7 +533,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/adapters/vercel-static:
     devDependencies:
@@ -557,7 +557,7 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/application:
     dependencies:
@@ -575,13 +575,13 @@ importers:
         version: 0.2.17
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-bundle-analyzer:
         specifier: ^1.3.9
         version: 1.3.9
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(@vite-pwa/assets-generator@1.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(workbox-build@7.4.0)(workbox-window@7.4.0)
+        version: 1.3.0(@vite-pwa/assets-generator@1.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
     devDependencies:
       '@rooted/components':
         specifier: workspace:^
@@ -631,7 +631,7 @@ importers:
         version: 4.23.1
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/elements:
     devDependencies:
@@ -687,7 +687,7 @@ importers:
         version: 4.23.1
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   packages/storage:
     devDependencies:
@@ -1802,6 +1802,10 @@ packages:
 
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/css-tree@4.0.5':
+    resolution: {integrity: sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/object-schema@3.0.5':
@@ -4283,8 +4287,8 @@ packages:
     peerDependencies:
       eslint: ^8.45.0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-unicorn@66.0.0:
-    resolution: {integrity: sha512-+ywdy8T3foyZ2t3nRBujGa3vfOVMobHIi5iLB0L+fogdVO3EiUJ4BAyIacogWytnweLw3hgT70LQL9KoKTY/kA==}
+  eslint-plugin-unicorn@72.0.0:
+    resolution: {integrity: sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==}
     engines: {node: '>=22'}
     peerDependencies:
       eslint: '>=10.4'
@@ -4754,6 +4758,10 @@ packages:
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
+  identifier-regex@1.1.0:
+    resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
+    engines: {node: '>=18'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4884,6 +4892,10 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-identifier@1.1.0:
+    resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
+    engines: {node: '>=18'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -5274,6 +5286,9 @@ packages:
 
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdn-data@2.29.0:
+    resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
 
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
@@ -5877,6 +5892,10 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
+  quote-js-string@0.1.0:
+    resolution: {integrity: sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==}
+    engines: {node: '>=22'}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -5990,6 +6009,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7063,6 +7086,11 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -8260,6 +8288,11 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/css-tree@4.0.5':
+    dependencies:
+      mdn-data: 2.29.0
+      source-map-js: 1.2.1
+
   '@eslint/object-schema@3.0.5': {}
 
   '@eslint/plugin-kit@0.7.2':
@@ -9306,10 +9339,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@varlock/vite-integration@1.3.1(varlock@1.13.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))':
+  '@varlock/vite-integration@1.3.1(varlock@1.13.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       varlock: 1.13.0
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vite-pwa/assets-generator@1.0.2':
     dependencies:
@@ -9325,28 +9358,28 @@ snapshots:
       vite: 5.4.21(@types/node@26.1.1)(lightningcss@1.33.0)(terser@5.49.0)
       vue: 3.5.40(typescript@6.0.3)
 
-  '@vitest/browser-preview@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(vitest@4.1.10)':
+  '@vitest/browser-preview@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
@@ -9363,13 +9396,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -9395,7 +9428,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)':
+  '@voidzero-dev/vite-plus-core@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.141.0
       '@oxc-project/types': 0.141.0
@@ -9411,6 +9444,7 @@ snapshots:
       terser: 5.49.0
       tsx: 4.23.1
       typescript: 6.0.3
+      yaml: 2.9.0
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.2.6':
     optional: true
@@ -10452,25 +10486,29 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-unicorn@66.0.0(eslint@10.3.0(jiti@2.7.0)):
+  eslint-plugin-unicorn@72.0.0(eslint@10.3.0(jiti@2.7.0)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.3.0(jiti@2.7.0))
+      '@eslint/css-tree': 4.0.5
       browserslist: 4.28.7
       change-case: 5.4.4
       ci-info: 4.4.0
       core-js-compat: 3.49.0
       detect-indent: 7.0.2
+      entities: 4.5.0
       eslint: 10.3.0(jiti@2.7.0)
       find-up-simple: 1.0.1
       globals: 17.7.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
-      jsesc: 3.1.0
+      is-identifier: 1.1.0
       pluralize: 8.0.0
+      quote-js-string: 0.1.0
       regjsparser: 0.13.2
+      reserved-identifiers: 1.2.0
       semver: 7.8.5
       strip-indent: 4.1.1
+      yaml: 2.9.0
 
   eslint-scope@9.1.2:
     dependencies:
@@ -11075,6 +11113,10 @@ snapshots:
 
   idb@7.1.1: {}
 
+  identifier-regex@1.1.0:
+    dependencies:
+      reserved-identifiers: 1.2.0
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -11192,6 +11234,11 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-identifier@1.1.0:
+    dependencies:
+      identifier-regex: 1.1.0
+      super-regex: 1.1.0
 
   is-map@2.0.3: {}
 
@@ -11517,6 +11564,8 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdn-data@2.29.0: {}
+
   media-typer@1.1.1: {}
 
   meow@13.2.0: {}
@@ -11770,7 +11819,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxfmt@0.60.0(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))):
+  oxfmt@0.60.0(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -11793,7 +11842,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.60.0
       '@oxfmt/binding-win32-ia32-msvc': 0.60.0
       '@oxfmt/binding-win32-x64-msvc': 0.60.0
-      vite-plus: 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      vite-plus: 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint-tsgolint@7.0.2001:
     optionalDependencies:
@@ -11804,7 +11853,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))):
+  oxlint@1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.75.0
       '@oxlint/binding-android-arm64': 1.75.0
@@ -11826,7 +11875,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.75.0
       '@oxlint/binding-win32-x64-msvc': 1.75.0
       oxlint-tsgolint: 7.0.2001
-      vite-plus: 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      vite-plus: 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   p-each-series@3.0.0: {}
 
@@ -12045,6 +12094,8 @@ snapshots:
 
   quick-lru@4.0.1: {}
 
+  quote-js-string@0.1.0: {}
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -12196,6 +12247,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reserved-identifiers@1.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -13075,12 +13128,12 @@ snapshots:
 
   vite-bundle-analyzer@1.3.9: {}
 
-  vite-plugin-pwa@1.3.0(@vite-pwa/assets-generator@1.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(workbox-build@7.4.0)(workbox-window@7.4.0):
+  vite-plugin-pwa@1.3.0(@vite-pwa/assets-generator@1.0.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       workbox-build: 7.4.0
       workbox-window: 7.4.0
     optionalDependencies:
@@ -13088,24 +13141,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)):
+  vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.141.0
       '@oxlint/plugins': 1.73.0
-      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      '@voidzero-dev/vite-plus-core': 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)
-      oxfmt: 0.60.0(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)))
-      oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)))
+      '@voidzero-dev/vite-plus-core': 0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      oxfmt: 0.60.0(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.2.6(@types/node@26.1.1)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.6
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.6
@@ -13157,7 +13210,7 @@ snapshots:
       lightningcss: 1.33.0
       terser: 5.49.0
 
-  vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1):
+  vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -13171,6 +13224,7 @@ snapshots:
       jiti: 2.7.0
       terser: 5.49.0
       tsx: 4.23.1
+      yaml: 2.9.0
 
   vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.1)(change-case@5.4.4)(lightningcss@1.33.0)(postcss@8.5.23)(search-insights@2.17.3)(terser@5.49.0)(typescript@6.0.3):
     dependencies:
@@ -13222,10 +13276,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)):
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/browser-preview@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -13242,11 +13296,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1
-      '@vitest/browser-preview': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
       happy-dom: 20.11.1
     transitivePeerDependencies:
       - msw
@@ -13457,6 +13511,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/tooling/tsdown/src/inheritdoc.mts
+++ b/tooling/tsdown/src/inheritdoc.mts
@@ -66,12 +66,12 @@ function _resolveJsDocument(tsconfigPath: string, className: string, memberName:
 	// (project files + lib files from the tsconfig's lib setting)
 	let classSym: ts.Symbol | undefined
 	outer: for (const sf of program.getSourceFiles()) {
-		for (const stmt of sf.statements) {
+		for (const statement of sf.statements) {
 			if (
-				(ts.isInterfaceDeclaration(stmt) || ts.isClassDeclaration(stmt))
-				&& stmt.name?.text === className
+				(ts.isInterfaceDeclaration(statement) || ts.isClassDeclaration(statement))
+				&& statement.name?.text === className
 			) {
-				classSym = checker.getSymbolAtLocation(stmt.name)
+				classSym = checker.getSymbolAtLocation(statement.name)
 				if (classSym) break outer
 			}
 		}
@@ -84,8 +84,8 @@ function _resolveJsDocument(tsconfigPath: string, className: string, memberName:
 	const memberSym = type.getProperty(memberName)
 	if (!memberSym) return undefined
 
-	for (const decl of memberSym.getDeclarations() ?? []) {
-		const document = extractJsDocument(decl)
+	for (const declaration of memberSym.getDeclarations() ?? []) {
+		const document = extractJsDocument(declaration)
 		if (document) return document
 	}
 
@@ -100,20 +100,20 @@ function resolveTopLevelJsDocument(tsconfigPath: string, name: string): string |
 	let result: string | undefined = undefined
 
 	outer: for (const sf of program.getSourceFiles()) {
-		for (const stmt of sf.statements) {
-			if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === name) {
+		for (const statement of sf.statements) {
+			if (ts.isFunctionDeclaration(statement) && statement.name?.text === name) {
 				// Try each overload. JSDoc is usually on the first, but check all.
-				const document = extractJsDocument(stmt)
+				const document = extractJsDocument(statement)
 				if (document) {
 					result = document
 					break outer
 				}
 				// No `break`: continue scanning for the next overload.
 			}
-			else if (ts.isVariableStatement(stmt)) {
-				for (const decl of stmt.declarationList.declarations) {
-					if (ts.isIdentifier(decl.name) && decl.name.text === name) {
-						const document = extractJsDocument(stmt)
+			else if (ts.isVariableStatement(statement)) {
+				for (const declaration of statement.declarationList.declarations) {
+					if (ts.isIdentifier(declaration.name) && declaration.name.text === name) {
+						const document = extractJsDocument(statement)
 						if (document) {
 							result = document
 							break outer
@@ -136,22 +136,22 @@ function resolveTopLevelTypeDocument(tsconfigPath: string, name: string): string
 	let result: string | undefined = undefined
 
 	outer: for (const sf of program.getSourceFiles()) {
-		for (const stmt of sf.statements) {
+		for (const statement of sf.statements) {
 			if (
-				(ts.isInterfaceDeclaration(stmt) || ts.isClassDeclaration(stmt))
-				&& stmt.name?.text === name
+				(ts.isInterfaceDeclaration(statement) || ts.isClassDeclaration(statement))
+				&& statement.name?.text === name
 			) {
-				result = extractJsDocument(stmt)
+				result = extractJsDocument(statement)
 				if (result) break outer
 			}
-			else if (ts.isTypeAliasDeclaration(stmt) && stmt.name.text === name) {
-				result = extractJsDocument(stmt)
+			else if (ts.isTypeAliasDeclaration(statement) && statement.name.text === name) {
+				result = extractJsDocument(statement)
 				if (result) break outer
 				// No JSDoc on the alias itself: follow a simple type reference to find docs on the target.
-				if (ts.isTypeReferenceNode(stmt.type)) {
-					const sym = checker.getSymbolAtLocation(stmt.type.typeName)
-					for (const decl of sym?.getDeclarations() ?? []) {
-						result = extractJsDocument(decl)
+				if (ts.isTypeReferenceNode(statement.type)) {
+					const sym = checker.getSymbolAtLocation(statement.type.typeName)
+					for (const declaration of sym?.getDeclarations() ?? []) {
+						result = extractJsDocument(declaration)
 						if (result) break outer
 					}
 				}


### PR DESCRIPTION
Unicorn 72 broke the lint run in two ways.

It renamed `prevent-abbreviations` to `name-replacements`, so the rule we
configure no longer existed. The rename is straight across, the options are
the same shape. Its default replacement table did grow though, and one of the
new entries wants `application` shortened to `app`, which is the opposite of
how this repo names things. That replacement is switched off; the rest are
fair, so the abbreviations they flagged (`stmt`, `decl`, `proto`, `dep`,
`urlExpr`) are spelled out. All of those were local variables, no API changed.

It also ships `defaultOptions: [undefined]` on `logical-assignment-operators`,
which its own schema rejects. oxlint validates defaultOptions when it registers
a JS plugin, so that one bad entry stopped the whole plugin from loading. The
new plugin-unicorn.mjs wrapper drops empty defaults before oxlint sees them and
can be deleted once upstream fixes the metadata.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H8fhNhbfX5pVbJxdMuePj1